### PR TITLE
Dev/nodeletization cerb

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -57,6 +57,7 @@ find_package(catkin REQUIRED
     actionlib
     darknet_ros_msgs
     image_transport
+    nodelet
 )
 
 # Enable OPENCV in darknet
@@ -76,6 +77,7 @@ catkin_package(
     std_msgs
     darknet_ros_msgs
     image_transport
+    nodelet
   DEPENDS
     Boost
 )
@@ -156,6 +158,10 @@ if (CUDA_FOUND)
   cuda_add_executable(${PROJECT_NAME}
     src/yolo_object_detector_node.cpp
   )
+  
+  cuda_add_library(${PROJECT_NAME}_nodelet
+    src/yolo_object_detector_nodelet.cpp
+  )
 
 else()
 
@@ -212,9 +218,17 @@ else()
     src/yolo_object_detector_node.cpp
   )
 
+  add_library(${PROJECT_NAME}_nodelet
+    src/yolo_object_detector_nodelet.cpp
+  )
+
 endif()
 
 target_link_libraries(${PROJECT_NAME}
+  ${PROJECT_NAME}_lib
+)
+
+target_link_libraries(${PROJECT_NAME}_nodelet
   ${PROJECT_NAME}_lib
 )
 

--- a/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
+++ b/darknet_ros/include/darknet_ros/YoloObjectDetector.hpp
@@ -162,7 +162,7 @@ class YoloObjectDetector
   int frameHeight_;
 
   //! Publisher of the bounding box image.
-  ros::Publisher detectionImagePublisher_;
+  image_transport::Publisher detectionImagePublisher_;
 
   // Yolo running on thread.
   std::thread yoloThread_;

--- a/darknet_ros/launch/darknet_ros_nodelet.launch
+++ b/darknet_ros/launch/darknet_ros_nodelet.launch
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<launch>
+  <!-- Console launch prefix -->
+  <arg name="launch_prefix" default=""/>
+
+  <!-- Config and weights folder. -->
+  <arg name="yolo_weights_path"          default="$(find darknet_ros)/yolo_network_config/weights"/>
+  <arg name="yolo_config_path"           default="$(find darknet_ros)/yolo_network_config/cfg"/>
+
+  <!-- ROS parameter files -->
+  <arg name="ros_param_file"             default="$(find darknet_ros)/config/ros.yaml"/>
+  <arg name="network_param_file"         default="$(find darknet_ros)/config/yolov2-tiny.yaml"/>  
+
+  <!-- Load parameters -->
+  <rosparam command="load" ns="darknet_ros_nodelet" file="$(arg ros_param_file)"/>
+  <rosparam command="load" ns="darknet_ros_nodelet" file="$(arg network_param_file)"/>
+
+  <!-- Darknet and ros wrapper nodelet manager -->
+  <node name="darknet_ros_nodelet_manager" type="nodelet" pkg="nodelet" args="manager" output="screen"/>
+
+  <!-- Start darknet and ros wrapper -->
+  <node pkg="nodelet" type="nodelet" name="darknet_ros_nodelet" output="screen" launch-prefix="$(arg launch_prefix)" args="load darknet_ros_nodelet darknet_ros_nodelet_manager">
+    <param name="weights_path"          value="$(arg yolo_weights_path)" />
+    <param name="config_path"           value="$(arg yolo_config_path)" />
+  </node>
+
+
+ <!--<node name="republish" type="republish" pkg="image_transport" output="screen" 	args="compressed in:=/front_camera/image_raw raw out:=/camera/image_raw" /> -->
+</launch>

--- a/darknet_ros/nodelet_plugins.xml
+++ b/darknet_ros/nodelet_plugins.xml
@@ -1,0 +1,8 @@
+<library path="lib/libdarknet_ros_nodelet">
+
+  <!-- Darknet ROS Plugin -->
+  <class name="darknet_ros_nodelet" type="DarknetRosNodelet" base_class_type="nodelet::Nodelet">
+    <description>Darknet ROS Nodelet.</description>
+  </class>
+
+</library>

--- a/darknet_ros/package.xml
+++ b/darknet_ros/package.xml
@@ -20,8 +20,14 @@
   <depend>message_generation</depend>
   <depend>darknet_ros_msgs</depend>
   <depend>actionlib</depend>
+  <depend>nodelet</depend>
 
   <!-- Test dependencies -->
   <test_depend>rostest</test_depend>
   <test_depend>wget</test_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
+
 </package>

--- a/darknet_ros/src/YoloObjectDetector.cpp
+++ b/darknet_ros/src/YoloObjectDetector.cpp
@@ -162,7 +162,7 @@ void YoloObjectDetector::init()
                                                            objectDetectorLatch);
   boundingBoxesPublisher_ = nodeHandle_.advertise<darknet_ros_msgs::BoundingBoxes>(
       boundingBoxesTopicName, boundingBoxesQueueSize, boundingBoxesLatch);
-  detectionImagePublisher_ = nodeHandle_.advertise<sensor_msgs::Image>(detectionImageTopicName,
+  detectionImagePublisher_ = imageTransport_.advertise(detectionImageTopicName,
                                                                        detectionImageQueueSize,
                                                                        detectionImageLatch);
 

--- a/darknet_ros/src/yolo_object_detector_node.cpp
+++ b/darknet_ros/src/yolo_object_detector_node.cpp
@@ -1,5 +1,5 @@
 /*
- * yolo_obstacle_detector_node.cpp
+ * yolo_object_detector_node.cpp
  *
  *  Created on: Dec 19, 2016
  *      Author: Marko Bjelonic

--- a/darknet_ros/src/yolo_object_detector_nodelet.cpp
+++ b/darknet_ros/src/yolo_object_detector_nodelet.cpp
@@ -17,7 +17,10 @@ class DarknetRosNodelet : public nodelet::Nodelet {
 
   public:
     DarknetRosNodelet(){}
-    ~DarknetRosNodelet(){}
+    ~DarknetRosNodelet(){
+
+      if(darknet_ros_) delete darknet_ros_;
+    }
 
   private:
     virtual void onInit() {

--- a/darknet_ros/src/yolo_object_detector_nodelet.cpp
+++ b/darknet_ros/src/yolo_object_detector_nodelet.cpp
@@ -1,0 +1,34 @@
+/*
+ * yolo_object_detector_nodelet.cpp
+ *
+ *  Created on: Dec 19, 2016
+ *      Author: Marko Bjelonic
+ *   Institute: ETH Zurich, Robotic Systems Lab
+ */
+
+#include <darknet_ros/YoloObjectDetector.hpp>
+
+#include <ros/ros.h>
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+
+
+class DarknetRosNodelet : public nodelet::Nodelet {
+
+  public:
+    DarknetRosNodelet(){}
+    ~DarknetRosNodelet(){}
+
+  private:
+    virtual void onInit() {
+      
+      ros::NodeHandle NodeHandle("~");
+      NodeHandle = getPrivateNodeHandle();
+      darknet_ros_ = new darknet_ros::YoloObjectDetector(NodeHandle);
+    }
+
+    darknet_ros::YoloObjectDetector* darknet_ros_;
+};
+
+//Declare as a Plug-in
+PLUGINLIB_EXPORT_CLASS(DarknetRosNodelet, nodelet::Nodelet);


### PR DESCRIPTION
- Adding option to use nodelet to run darknet_ros
- Node version remains available and unaltered
- Using image transport to publish the detection image, this allows to send the compressed image and thereby might reduce data traffic a bit.
- Tested on Cerberus, confirmed that it slightly improves speed when running along with Elevation Mapping (EM update frequency increases by ~ 10 percent)